### PR TITLE
Add grid initializer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 #   $<TARGET_OBJECTS:minesweeper_base>
 #
 # https://cmake.org/cmake/help/v3.0/command/add_library.html
-add_library(minesweeper_base STATIC src/base/grid.cpp src/base/square.cpp)
+add_library(minesweeper_base STATIC src/base/grid.cpp src/base/square.cpp src/base/initializer.cpp)
 
 # Add the minesweeper executable itself
 add_executable(minesweeper src/main.cpp)

--- a/include/base/initializer.hpp
+++ b/include/base/initializer.hpp
@@ -53,14 +53,11 @@ class Initializer
      */
     unsigned int mine_to_number(unsigned int x, unsigned int y);
 
-    bool is_initialized(const Square& square) const
-    {
-      return square.initialized;
-    }
-    bool is_initialized(unsigned int x, unsigned int y) const
-    {
-      return is_initialized(grid.at(x, y));
-    }
+    /**
+     * get/set the initialized field on the given square.
+     */
+    bool initialized(const Square& square) const;
+    void initialized(Square& square, bool value);
 
     Grid& grid;
 };

--- a/include/base/initializer.hpp
+++ b/include/base/initializer.hpp
@@ -25,6 +25,14 @@ class Initializer
 
   protected:
     /**
+     * Set the mines on the grid, given the grid mine number.
+     *
+     * This method does NOT check if a mine has already been set on the game,
+     * calling it in this case would result in an incorrect number of mines.
+     */
+    void set_mines();
+
+    /**
      * Once the mines have been set, call this method to fill the adjacent
      * mine numbers on the remaining squares.
      */

--- a/include/base/initializer.hpp
+++ b/include/base/initializer.hpp
@@ -1,0 +1,68 @@
+#ifndef BASE_INITIALIZER_HPP
+#define BASE_INITIALIZER_HPP
+
+#include "grid.hpp"
+
+/**
+ * Base class to initialize a Grid.
+ *
+ * Square is friend with this class, allowing to modify the internal data
+ * structure.
+ *
+ * It is a class and not a function to enable inheritance, which permits to
+ * keep the "friendship" benefit.
+ *
+ * Usage:
+ *
+ *  Initializer()(grid)
+ */
+class Initializer
+{
+  public:
+    Initializer(Grid& grid);
+
+    void operator() ();
+
+  protected:
+    /**
+     * Once the mines have been set, call this method to fill the adjacent
+     * mine numbers on the remaining squares.
+     */
+    void fill_adjacent_mine_numbers();
+
+    /**
+     * Returns the number of mine adjacent to (x, y)
+     */
+    unsigned int adjacent_mine_number(unsigned int x, unsigned int y);
+
+    /**
+     * Returns 1 or 0 depending on if the square in the direction relative
+     * to (x, y) has a mine or not.
+     */
+    unsigned int mine_top_left(unsigned int x, unsigned int y);
+    unsigned int mine_top(unsigned int x, unsigned int y);
+    unsigned int mine_top_right(unsigned int x, unsigned int y);
+    unsigned int mine_left(unsigned int x, unsigned int y);
+    unsigned int mine_right(unsigned int x, unsigned int y);
+    unsigned int mine_bottom_left(unsigned int x, unsigned int y);
+    unsigned int mine_bottom(unsigned int x, unsigned int y);
+    unsigned int mine_bottom_right(unsigned int x, unsigned int y);
+
+    /**
+     * Returns 1 or 0 depending on if the square at (x, y) has a mine or not
+     */
+    unsigned int mine_to_number(unsigned int x, unsigned int y);
+
+    bool is_initialized(const Square& square) const
+    {
+      return square.initialized;
+    }
+    bool is_initialized(unsigned int x, unsigned int y) const
+    {
+      return is_initialized(grid.at(x, y));
+    }
+
+    Grid& grid;
+};
+
+#endif // BASE_INITIALIZER_HPP

--- a/include/base/square.hpp
+++ b/include/base/square.hpp
@@ -7,6 +7,12 @@ class Square
 {
   public:
     /**
+     * Square is friend with Initializer so it can change the internal
+     * data structure.
+     */
+    friend class Initializer;
+
+    /**
      * Set clicked to true and return mine() if not flagged()
      *
      * If flagged(), return false
@@ -28,6 +34,9 @@ class Square
     bool unflag();
 
     bool mine() const;
+    /**
+     * Set mine to the given value, if the square is not already initialized.
+     */
     void mine(bool mine);
 
     bool clicked() const;
@@ -37,9 +46,15 @@ class Square
     void flagged(bool flagged);
 
     uint8_t adjacent_mine_number() const;
+    /**
+     * Set adjacent_mine_number to the given value, if the square is not
+     * already initialized.
+     */
     void adjacent_mine_number(uint8_t number);
 
   private:
+    bool initialized{false};
+
     bool mine_{false};
     bool clicked_{false};
     bool flagged_{false};

--- a/src/base/grid.cpp
+++ b/src/base/grid.cpp
@@ -104,8 +104,7 @@ void Grid::print() const
       {
         std::cout << 'U';
       }
-      std::cout << +square.adjacent_mine_number()
-        << "  ";
+      std::cout << +square.adjacent_mine_number() << "  ";
     }
     std::cout << std::endl;
   }

--- a/src/base/initializer.cpp
+++ b/src/base/initializer.cpp
@@ -1,0 +1,163 @@
+#include "base/initializer.hpp"
+
+#include <random>
+
+Initializer::Initializer(Grid& grid)
+  :grid(grid)
+{
+}
+
+void Initializer::operator() ()
+{
+  std::random_device rd;
+  std::default_random_engine engine(rd());
+
+  std::uniform_int_distribution<unsigned int> line_dist(0, grid.line() - 1);
+  std::uniform_int_distribution<unsigned int> column_dist(0, grid.column() - 1);
+
+  unsigned int mine_number = 0;
+
+  while (mine_number < grid.mine_number())
+  {
+    unsigned int line = line_dist(engine);
+    unsigned int column = column_dist(engine);
+
+    Square& square = grid.at(line, column);
+
+    if (! square.initialized)
+    {
+      square.mine(true);
+      square.initialized = true;
+      ++mine_number;
+    }
+  }
+  fill_adjacent_mine_numbers();
+}
+
+void Initializer::fill_adjacent_mine_numbers()
+{
+  for (unsigned int x = 0; x < grid.line(); ++x)
+  {
+    for (unsigned int y = 0; y < grid.column(); ++y)
+    {
+      Square& square = grid.at(x, y);
+      if (! square.initialized)
+      {
+        square.adjacent_mine_number(adjacent_mine_number(x, y));
+        square.initialized = true;
+      }
+    }
+  }
+}
+
+unsigned int Initializer::adjacent_mine_number(unsigned int x, unsigned int y)
+{
+  return
+    mine_top_left(x, y) +
+    mine_top(x, y) +
+    mine_top_right(x, y) +
+    mine_left(x, y) +
+    mine_right(x, y) +
+    mine_bottom_left(x, y) +
+    mine_bottom(x, y) +
+    mine_bottom_right(x, y);
+}
+
+unsigned int Initializer::mine_top_left(unsigned int x, unsigned int y)
+{
+  if (x > 0)
+  {
+    if (y > 0)
+    {
+      return mine_to_number(x - 1, y - 1);
+    }
+  }
+
+  return 0;
+}
+
+unsigned int Initializer::mine_top(unsigned int x, unsigned int y)
+{
+  if (x > 0)
+  {
+    return mine_to_number(x - 1, y);
+  }
+
+  return 0;
+}
+
+unsigned int Initializer::mine_top_right(unsigned int x, unsigned int y)
+{
+  if (x > 0)
+  {
+    if (y < grid.column() - 1)
+    {
+      return mine_to_number(x - 1, y + 1);
+    }
+  }
+
+  return 0;
+}
+
+unsigned int Initializer::mine_left(unsigned int x, unsigned int y)
+{
+  if (y > 0)
+  {
+    return mine_to_number(x, y - 1);
+  }
+
+  return 0;
+}
+
+unsigned int Initializer::mine_right(unsigned int x, unsigned int y)
+{
+  if (y < grid.column() - 1)
+  {
+    return mine_to_number(x, y + 1);
+  }
+
+  return 0;
+}
+
+unsigned int Initializer::mine_bottom_left(unsigned int x, unsigned int y)
+{
+  if (x < grid.line() - 1)
+  {
+    if (y > 0)
+    {
+      return mine_to_number(x + 1, y - 1);
+    }
+  }
+
+  return 0;
+}
+
+unsigned int Initializer::mine_bottom(unsigned int x, unsigned int y)
+{
+  if (x < grid.line() - 1)
+  {
+    return mine_to_number(x + 1, y);
+  }
+
+  return 0;
+}
+
+unsigned int Initializer::mine_bottom_right(unsigned int x, unsigned int y)
+{
+  if (x < grid.line() - 1)
+  {
+    if (y < grid.column() - 1)
+    {
+      return mine_to_number(x + 1, y + 1);
+    }
+  }
+
+  return 0;
+}
+
+unsigned int Initializer::mine_to_number(unsigned int x, unsigned int y)
+{
+  // bool to int is totally legal in C++
+  return grid.at(x, y).mine();
+}
+

--- a/src/base/initializer.cpp
+++ b/src/base/initializer.cpp
@@ -24,10 +24,10 @@ void Initializer::operator() ()
 
     Square& square = grid.at(line, column);
 
-    if (! square.initialized)
+    if (! initialized(square))
     {
       square.mine(true);
-      square.initialized = true;
+      initialized(square, true);
       ++mine_number;
     }
   }
@@ -41,10 +41,10 @@ void Initializer::fill_adjacent_mine_numbers()
     for (unsigned int y = 0; y < grid.column(); ++y)
     {
       Square& square = grid.at(x, y);
-      if (! square.initialized)
+      if (! initialized(square))
       {
         square.adjacent_mine_number(adjacent_mine_number(x, y));
-        square.initialized = true;
+        initialized(square, true);
       }
     }
   }
@@ -161,3 +161,12 @@ unsigned int Initializer::mine_to_number(unsigned int x, unsigned int y)
   return grid.at(x, y).mine();
 }
 
+bool Initializer::initialized(const Square& square) const
+{
+  return square.initialized;
+}
+
+void Initializer::initialized(Square& square, bool value)
+{
+  square.initialized = value;
+}

--- a/src/base/initializer.cpp
+++ b/src/base/initializer.cpp
@@ -9,6 +9,12 @@ Initializer::Initializer(Grid& grid)
 
 void Initializer::operator() ()
 {
+  set_mines();
+  fill_adjacent_mine_numbers();
+}
+
+void Initializer::set_mines()
+{
   std::random_device rd;
   std::default_random_engine engine(rd());
 
@@ -31,7 +37,6 @@ void Initializer::operator() ()
       ++mine_number;
     }
   }
-  fill_adjacent_mine_numbers();
 }
 
 void Initializer::fill_adjacent_mine_numbers()

--- a/src/base/square.cpp
+++ b/src/base/square.cpp
@@ -40,7 +40,10 @@ bool Square::mine() const
 
 void Square::mine(bool mine)
 {
-  this->mine_ = mine;
+  if (!this->initialized)
+  {
+    this->mine_ = mine;
+  }
 }
 
 bool Square::clicked() const
@@ -70,5 +73,8 @@ uint8_t Square::adjacent_mine_number() const
 
 void Square::adjacent_mine_number(uint8_t number)
 {
-  this->adjacent_mine_number_ = number;
+  if (!this->initialized)
+  {
+    this->adjacent_mine_number_ = number;
+  }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,10 @@
 #include <iostream>
 #include "base/grid.hpp"
+#include "base/initializer.hpp"
 
 int main() {
   Grid g{5, 5, 5};
+  Initializer{g}();
 
   g.print();
   return 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,3 +26,4 @@ endfunction()
 
 create_test(test_base_square.cpp)
 create_test(test_base_grid.cpp)
+create_test(test_base_initializer.cpp)

--- a/test/test_base_initializer.cpp
+++ b/test/test_base_initializer.cpp
@@ -1,0 +1,166 @@
+#define BOOST_TEST_MODULE Base::Initializer
+#include <boost/test/unit_test.hpp>
+using namespace boost::unit_test;
+
+#include "base/initializer.hpp"
+
+#include <memory>     // std::shared_ptr, std::make_shared
+#include <functional> // std::bind
+
+class Tester : public Initializer
+{
+  public:
+    Grid grid{5, 5, 5};
+
+    Tester() :Initializer{grid} {}
+};
+
+BOOST_FIXTURE_TEST_SUITE(Base_Initializer, Tester)
+
+BOOST_AUTO_TEST_CASE(test_call)
+{
+  (*this)();
+
+  unsigned int mine_number = 0;
+
+  for(unsigned int x = 0; x < 5; ++x)
+  {
+    for(unsigned int y = 0; y < 5; ++y)
+    {
+      if (grid.at(x, y).mine())
+      {
+        ++mine_number;
+      }
+      BOOST_TEST(is_initialized(x, y));
+    }
+  }
+
+  BOOST_CHECK_EQUAL(5U, mine_number);
+}
+
+BOOST_AUTO_TEST_CASE(test_fill_adjacent_mine_numbers)
+{
+  grid.at(0, 0).mine(true);
+  grid.at(2, 2).mine(true);
+  grid.at(4, 3).mine(true);
+
+  fill_adjacent_mine_numbers();
+
+  unsigned int expected[5][5] = {
+    {0, 1, 0, 0, 0},
+    {1, 2, 1, 1, 0},
+    {0, 1, 0, 1, 0},
+    {0, 1, 2, 2, 1},
+    {0, 0, 1, 0, 1}
+  };
+
+  for(unsigned int x = 0; x < 5; ++x)
+  {
+    for(unsigned int y = 0; y < 5; ++y)
+    {
+      BOOST_CHECK_EQUAL(expected[x][y],
+          grid.at(x, y).adjacent_mine_number());
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_adjacent_mine_number)
+{
+  grid.at(0, 0).mine(true);
+  grid.at(1, 0).mine(true);
+  grid.at(1, 1).mine(true);
+  grid.at(1, 2).mine(true);
+
+  BOOST_CHECK_EQUAL(4U, adjacent_mine_number(0, 1));
+  BOOST_CHECK_EQUAL(2U, adjacent_mine_number(0, 2));
+  BOOST_CHECK_EQUAL(1U, adjacent_mine_number(0, 3));
+  BOOST_CHECK_EQUAL(0U, adjacent_mine_number(0, 4));
+
+  BOOST_CHECK_EQUAL(2U, adjacent_mine_number(2, 0));
+  BOOST_CHECK_EQUAL(3U, adjacent_mine_number(2, 1));
+  BOOST_CHECK_EQUAL(2U, adjacent_mine_number(2, 2));
+  BOOST_CHECK_EQUAL(1U, adjacent_mine_number(2, 3));
+  BOOST_CHECK_EQUAL(0U, adjacent_mine_number(2, 4));
+}
+
+BOOST_AUTO_TEST_CASE(test_mine_top_left)
+{
+  grid.at(0, 0).mine(true);
+
+  BOOST_CHECK_EQUAL(0U, mine_top_left(0, 0));
+  BOOST_CHECK_EQUAL(0U, mine_top_left(0, 1));
+  BOOST_CHECK_EQUAL(0U, mine_top_left(1, 0));
+  BOOST_CHECK_EQUAL(1U, mine_top_left(1, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_mine_top)
+{
+  grid.at(0, 0).mine(true);
+
+  BOOST_CHECK_EQUAL(0U, mine_top(0, 0));
+  BOOST_CHECK_EQUAL(0U, mine_top(0, 1));
+  BOOST_CHECK_EQUAL(1U, mine_top(1, 0));
+  BOOST_CHECK_EQUAL(0U, mine_top(1, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_mine_top_right)
+{
+  grid.at(0, 4).mine(true);
+
+  BOOST_CHECK_EQUAL(0U, mine_top_right(0, 4));
+  BOOST_CHECK_EQUAL(0U, mine_top_right(0, 3));
+  BOOST_CHECK_EQUAL(0U, mine_top_right(1, 4));
+  BOOST_CHECK_EQUAL(1U, mine_top_right(1, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_mine_left)
+{
+  grid.at(0, 0).mine(true);
+
+  BOOST_CHECK_EQUAL(0U, mine_left(0, 0));
+  BOOST_CHECK_EQUAL(1U, mine_left(0, 1));
+  BOOST_CHECK_EQUAL(0U, mine_left(1, 0));
+  BOOST_CHECK_EQUAL(0U, mine_left(1, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_mine_right)
+{
+  grid.at(0, 4).mine(true);
+
+  BOOST_CHECK_EQUAL(0U, mine_right(0, 4));
+  BOOST_CHECK_EQUAL(1U, mine_right(0, 3));
+  BOOST_CHECK_EQUAL(0U, mine_right(1, 4));
+  BOOST_CHECK_EQUAL(0U, mine_right(1, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_mine_bottom_left)
+{
+  grid.at(4, 0).mine(true);
+
+  BOOST_CHECK_EQUAL(0U, mine_bottom_left(4, 0));
+  BOOST_CHECK_EQUAL(0U, mine_bottom_left(4, 1));
+  BOOST_CHECK_EQUAL(0U, mine_bottom_left(3, 0));
+  BOOST_CHECK_EQUAL(1U, mine_bottom_left(3, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_mine_bottom)
+{
+  grid.at(4, 0).mine(true);
+
+  BOOST_CHECK_EQUAL(0U, mine_bottom(4, 0));
+  BOOST_CHECK_EQUAL(0U, mine_bottom(4, 1));
+  BOOST_CHECK_EQUAL(1U, mine_bottom(3, 0));
+  BOOST_CHECK_EQUAL(0U, mine_bottom(3, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_mine_bottom_right)
+{
+  grid.at(4, 4).mine(true);
+
+  BOOST_CHECK_EQUAL(0U, mine_bottom_right(4, 4));
+  BOOST_CHECK_EQUAL(0U, mine_bottom_right(4, 3));
+  BOOST_CHECK_EQUAL(0U, mine_bottom_right(3, 4));
+  BOOST_CHECK_EQUAL(1U, mine_bottom_right(3, 3));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_base_initializer.cpp
+++ b/test/test_base_initializer.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(test_call)
       {
         ++mine_number;
       }
-      BOOST_TEST(is_initialized(x, y));
+      BOOST_TEST(initialized(grid.at(x, y)));
     }
   }
 


### PR DESCRIPTION
Add Initializer, as a friend class of Square, so it can change the Square's new `initialized` field.

This is developed as a class so it can be derived to add other initialization strategies, such as opening the game on a region. 