### PR TITLE
Added Initializer factory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Compiler flags to add (a lot) of warnings
-add_compile_options(-Wall -Wextra -pedantic)
+add_compile_options(-Wall -Wextra -pedantic -fconcepts)
 
 # Conan
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/include/base/initializer.hpp
+++ b/include/base/initializer.hpp
@@ -1,6 +1,10 @@
 #ifndef BASE_INITIALIZER_HPP
 #define BASE_INITIALIZER_HPP
 
+#include <unordered_map>
+#include <memory>
+#include <functional>
+
 #include "grid.hpp"
 
 /**
@@ -12,18 +16,83 @@
  * It is a class and not a function to enable inheritance, which permits to
  * keep the "friendship" benefit.
  *
- * Usage:
+ * Basic usage:
  *
- *  Initializer()(grid)
+ * ```cpp
+ * Initializer(grid).initialize();
+ * ```
+ *
+ * ALternatively, Initializer is also a factory:
+ *
+ * ```cpp
+ * // register different types
+ * Initializer::add<Initializer>("defaut");
+ * Initializer::add<AnotherInitializer>("another");
+ *
+ * // make without name defaults to "default"
+ * Initializer::make(grid);
+ * Initializer::make(grid, "another");
+ * ```
  */
 class Initializer
 {
   public:
     Initializer(Grid& grid);
 
-    void operator() ();
+    virtual void initialize();
+
+    /**
+     * Initializer::add<Initializer>("default");
+     *
+     * Will register the template type as an initializer associated with the given name.
+     */
+#if defined(__cpp_concepts) && __cpp_concepts >= 201507
+    /**
+     * This versions works with concepts, a C++20 feature which provides better
+     * diagnostic messages, such as:
+     *
+     * > error: no matching function for call to ‘Initializer::add<Grid>(const char [8])’
+     * > note:   constraints not satisfied
+     * > note: ‘is_base_of_v<Initializer, T>’ evaluated to false
+     * > note: ‘is_convertible_v<T*, Initializer*>’ evaluated to false
+     */
+    template<class T>
+      requires (std::is_base_of_v<Initializer, T> && std::is_convertible_v<T*, Initializer*>)
+    static void add(const std::string& name)
+    {
+      initializers.insert_or_assign(name,
+          // we cast to the desired type to select the correct overload,
+          // which is needed otherwise we don't know which one is wanted.
+          static_cast<std::unique_ptr<T> (*) (Grid&)> (std::make_unique<T>) );
+    }
+#else
+    /**
+     * This version works without concepts, but on substitution error will issue message such as:
+     *
+     * > error: no matching function for call to ‘Initializer::add<Grid>(const char [8])’
+     * > error: no type named ‘type’ in ‘struct std::enable_if<false, void>’
+     */
+    template<class T,
+      typename = std::enable_if_t<std::is_base_of_v<Initializer, T>>
+      >
+    static void add(const std::string& name)
+    {
+      initializers.insert_or_assign(name, static_cast<std::unique_ptr<T> (*) (Grid&)>(std::make_unique<T>) );
+    }
+#endif
+
+    /**
+     * Make a new Initializer, using the "default" name.
+     */
+    static std::unique_ptr<Initializer> make(Grid& grid);
+    /**
+     * Make a new Initializer, using the given name.
+     */
+    static std::unique_ptr<Initializer> make(Grid& grid, const std::string& name);
 
   protected:
+    static std::unordered_map<std::string, std::function<std::unique_ptr<Initializer>(Grid&)>> initializers;
+
     /**
      * Set the mines on the grid, given the grid mine number.
      *

--- a/src/base/initializer.cpp
+++ b/src/base/initializer.cpp
@@ -2,12 +2,31 @@
 
 #include <random>
 
+std::unordered_map<std::string, std::function<std::unique_ptr<Initializer>(Grid&)>> Initializer::initializers;
+
+std::unique_ptr<Initializer> Initializer::make(Grid& grid)
+{
+  return make(grid, "default");
+}
+
+std::unique_ptr<Initializer> Initializer::make(Grid& grid, const std::string& name)
+{
+  try
+  {
+    return initializers.at(name)(grid);
+  }
+  catch (const std::out_of_range& ex)
+  {
+    return nullptr;
+  }
+}
+
 Initializer::Initializer(Grid& grid)
   :grid(grid)
 {
 }
 
-void Initializer::operator() ()
+void Initializer::initialize()
 {
   set_mines();
   fill_adjacent_mine_numbers();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,8 +3,11 @@
 #include "base/initializer.hpp"
 
 int main() {
+  Initializer::add<Initializer> ("default");
+
   Grid g{5, 5, 5};
-  Initializer{g}();
+
+  Initializer::make(g)->initialize();
 
   g.print();
   return 0;

--- a/test/test_base_initializer.cpp
+++ b/test/test_base_initializer.cpp
@@ -4,22 +4,35 @@ using namespace boost::unit_test;
 
 #include "base/initializer.hpp"
 
-#include <memory>     // std::shared_ptr, std::make_shared
-#include <functional> // std::bind
-
 class Tester : public Initializer
 {
   public:
     Grid grid{5, 5, 5};
 
     Tester() :Initializer{grid} {}
+    Tester(Grid& grid) :Initializer{grid} {}
 };
+
+BOOST_AUTO_TEST_CASE(test_factory)
+{
+  Grid grid{5, 5, 5};
+  Initializer::add<Initializer>("default");
+  Initializer::add<Tester>("test");
+
+  auto init1 = Initializer::make(grid);
+  auto init2 = Initializer::make(grid, "test");
+
+  BOOST_CHECK(dynamic_cast<Initializer*>(init1.get()) != nullptr);
+  BOOST_CHECK(dynamic_cast<Tester*>(init2.get()) != nullptr);
+
+  BOOST_CHECK(Initializer::make(grid, "foo") == nullptr);
+}
 
 BOOST_FIXTURE_TEST_SUITE(Base_Initializer, Tester)
 
 BOOST_AUTO_TEST_CASE(test_call)
 {
-  (*this)();
+  this->initialize();
 
   unsigned int mine_number = 0;
 


### PR DESCRIPTION
Added a factory pattern to `Initializer`, used with

```cpp
// register different types
Initializer::add<Initializer>("defaut");
Initializer::add<AnotherInitializer>("another");

// make without name defaults to "default"
Initializer::make(grid);
Initializer::make(grid, "another");
```